### PR TITLE
Berlin hackathon

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,6 @@ ARG MARIADB_VERSION='10.5'
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-# This volume should be defined first, because we don't want the default DB to be preserved
-# VOLUME db:/var/lib/mysql
-
 RUN apt-get update && \
 	# Installing Tor, Supervisor
 	apt-get install -y --no-install-recommends tor supervisor && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,25 @@
-FROM wordpress:6.0.0-php8.1-apache
-MAINTAINER Dmitry Danilov <dima.danilov9867@gmail.com>
+FROM wordpress:6.0.0-php8.0-apache
+LABEL org.opencontainers.image.authors="Dmitry Danilov <dima.danilov9867@gmail.com>"
 
 ARG MARIADB_VERSION='10.5'
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-# RUN apt-get update && \
-#     apt-get install -y tor supervisor && \
-#     apt-get clean && rm -rf /var/lib/apt/lists/*
+# This volume should be defined first, because we don't want the default DB to be preserved
+# VOLUME db:/var/lib/mysql
 
-# Tor, Supervisor
 RUN apt-get update && \
-	apt-get install -y --no-install-recommends tor supervisor
-
-# MariaDB
-RUN apt-get update && apt-get install -y --no-install-recommends software-properties-common gnupg && \
+	# Installing Tor, Supervisor
+	apt-get install -y --no-install-recommends tor supervisor && \
+	# Installing MariaDB
+	apt-get install -y --no-install-recommends software-properties-common gnupg && \
 	apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xF1656F24C74CD1D8 && \
 	echo 'deb [arch=amd64,arm64,ppc64el] http://sfo1.mirrors.digitalocean.com/mariadb/repo/'${MARIADB_VERSION}'/debian bullseye main' > /etc/apt/sources.list.d/mariadb.list && \
-	apt-get update && apt-get install -y --no-install-recommends mariadb-server gosu
-
-# To be fixed
-RUN mkdir /var/run/mysqld
+	apt-get update && apt-get install -y --no-install-recommends mariadb-server gosu && \
+	# Fixing initialization of a new DB when needed
+	mkdir /run/mysqld /docker-entrypoint-initdb.d && rm -rf /var/lib/mysql && \
+	# Cleaning up installation files
+	apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY files/mariadb-entrypoint.sh /usr/local/bin/mariadb-entrypoint.sh
 COPY files/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
@@ -29,6 +28,7 @@ ADD files/mytune.cnf /etc/mysql/mariadb.conf.d/99-mytune.cnf
 
 VOLUME /var/www/html
 VOLUME /var/lib/tor
+VOLUME /var/lib/mysql
 
 EXPOSE 80
 EXPOSE 3306

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Torpress
+
+Torpress is a project to help small media outlets to serve their WordPress websites through the Tor network to resist censorship.
+
+## How it works
+
+By starting a single container you are getting a WordPress website in the Tor network, which is very resilient to blocking and censorship. To access such websites a [Tor browser](https://www.torproject.org/) is needed.
+
+## Usage
+
+```
+docker create --name torpress torpress:latest
+docker start torpress
+docker exec -it $(docker ps -f "name=torpress" -q) cat /var/lib/tor/hidden_service/hostname
+```
+The last command should output the address of your new website in the Tor network. It might take a little while for the address to be broadcasted in the network.

--- a/files/torrc
+++ b/files/torrc
@@ -72,6 +72,7 @@ SocksPort 0
 
 HiddenServiceDir /var/lib/tor/hidden_service/
 HiddenServicePort 80 127.0.0.1:80
+HiddenServicePort 8080 127.0.0.1:80
 #HiddenServicePort 22 127.0.0.1:22
 
 #HiddenServiceDir /var/lib/tor/other_hidden_service/


### PR DESCRIPTION
- Fixed database initialization (when installed through `apt`, a default database is created, so initialization of the WordPress database was not triggered)
- Fixed Tor configuration (WordPress thinks it always runs on 8080. Apach configuration can't be supplied in the container, since it is generated by the WordPress startup script. So the solution is to configure Tor to serve both ports)
- Downgraded php to 8.0 because of cookie errors
- Added README.md